### PR TITLE
VEOSS-885 | Added validation to JSON Reads

### DIFF
--- a/app/uk/gov/hmrc/onestopshopreturnsstub/models/core/CoreRate.scala
+++ b/app/uk/gov/hmrc/onestopshopreturnsstub/models/core/CoreRate.scala
@@ -16,11 +16,10 @@
 
 package uk.gov.hmrc.onestopshopreturnsstub.models.core
 
-import play.api.libs.json.{OFormat, OWrites, Reads, __}
+import play.api.libs.json.{Format, Reads, Writes, __}
+import uk.gov.hmrc.onestopshopreturnsstub.utils.ValidationUtils._
 
-import java.time.{Instant, LocalDate, LocalDateTime}
-import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
-
+import java.time.LocalDate
 
 case class CoreRate(publishedDate: LocalDate, rate: BigDecimal)
 
@@ -29,23 +28,22 @@ object CoreRate {
   val reads: Reads[CoreRate] = {
 
     import play.api.libs.functional.syntax._
-
     (
-      (__ \ "publishedDate").read[LocalDate] and
-        (__ \ "rate").read[BigDecimal]
-      ) (CoreRate.apply _)
+      (__ \ "publishedDate").read[LocalDate](validatedDateRead) and
+      (__ \ "rate").read[BigDecimal]
+    ) (CoreRate.apply _)
   }
 
-  val writes: OWrites[CoreRate] = {
+  val writes: Writes[CoreRate] = {
 
     import play.api.libs.functional.syntax._
 
     (
       (__ \ "publishedDate").write[LocalDate] and
-        (__ \ "rate").write[BigDecimal]
-      ) (unlift(CoreRate.unapply))
+      (__ \ "rate").write[BigDecimal]
+    ) (unlift(CoreRate.unapply))
   }
 
-  implicit val format: OFormat[CoreRate] = OFormat(reads, writes)
+  implicit val format: Format[CoreRate] = Format(reads, writes)
 
 }

--- a/app/uk/gov/hmrc/onestopshopreturnsstub/utils/ValidationUtils.scala
+++ b/app/uk/gov/hmrc/onestopshopreturnsstub/utils/ValidationUtils.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.onestopshopreturnsstub.utils
+
+import play.api.libs.json.{JsString, JsonValidationError, Reads, Writes}
+
+import java.time.format.DateTimeFormatterBuilder
+import java.time.{Instant, LocalDate, LocalDateTime, ZoneOffset}
+import scala.util.Try
+
+object ValidationUtils {
+
+  private val dateRegex = "([1-9]\\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01]))"
+
+  private val currencyRegex = "^[\\d]+|[\\d]+\\.\\d{2}$"
+
+  private val vatRateRegex = "^[\\d]{1,3}(\\.\\d{2})?$"
+
+  private val dateTimeWithMillisecondsFormatter = new DateTimeFormatterBuilder()
+    .appendPattern("yyyy-MM-dd")
+    .appendLiteral('T')
+    .appendPattern("hh:mm:ss.SSS")
+    .appendLiteral('Z')
+    .toFormatter
+
+  def range[A](from: Int, to: Int)(implicit reads: Reads[A], p: A => scala.collection.Iterable[_]): Reads[A] =
+    Reads.filter[A](JsonValidationError(s"Collection must have between $from and $to values", from))(x => x.size >= from && x.size <= to)
+
+  val validatedDateRead: Reads[LocalDate] =
+    Reads.pattern(dateRegex.r, "Not a valid date with format yyyy-MM-dd")
+      .map( x => LocalDate.parse(x))
+
+  val validatedDateTimeRead: Reads[LocalDateTime] =
+    Reads.filter[JsString](JsonValidationError("Not a valid date-time of format yyyy-MM-ddThh:mm:ss.SSSZ"))(
+    (x: JsString) =>  Try { dateTimeWithMillisecondsFormatter.parse(x.value) }.isSuccess)
+    .map(x => LocalDateTime.ofInstant(Instant.parse(x.value), ZoneOffset.of("Z")))
+
+  val localDateTimeWrites: Writes[LocalDateTime] = Writes[LocalDateTime] {
+    localDateTime => JsString(dateTimeWithMillisecondsFormatter.format(localDateTime)) }
+
+  val currencyRead = implicitly[Reads[BigDecimal]]
+    .filter(JsonValidationError("Value can only have 2 decimal places"))(x => x.toString.matches(currencyRegex))
+
+  val vatRateRead = implicitly[Reads[BigDecimal]]
+    .filter(JsonValidationError("Value can only have 2 decimal places"))(x => x.toString.matches(vatRateRegex))
+    .filter(JsonValidationError("Value cannot be 0"))(x => x > 0)
+    .filter(JsonValidationError("Value must be below 100"))(x => x <= 100)
+
+}

--- a/test/uk/gov/hmrc/onestopshopreturnsstub/controllers/CoreControllerSpec.scala
+++ b/test/uk/gov/hmrc/onestopshopreturnsstub/controllers/CoreControllerSpec.scala
@@ -22,15 +22,15 @@ import play.api.http.HeaderNames.{ACCEPT, AUTHORIZATION, CONTENT_TYPE, DATE}
 import play.api.http.{MimeTypes, Status}
 import play.api.libs.json.Json
 import play.api.mvc.Headers
-import play.api.test.{FakeRequest, Helpers}
 import play.api.test.Helpers._
-import uk.gov.hmrc.onestopshopreturnsstub.models.core._
+import play.api.test.{FakeRequest, Helpers}
 import uk.gov.hmrc.onestopshopreturnsstub.models.Period
 import uk.gov.hmrc.onestopshopreturnsstub.models.Quarter._
+import uk.gov.hmrc.onestopshopreturnsstub.models.core._
 import uk.gov.hmrc.onestopshopreturnsstub.utils.JsonSchemaHelper
 
 import java.time.format.DateTimeFormatter
-import java.time.{Clock, Instant, LocalDate, LocalDateTime, ZoneId, ZoneOffset}
+import java.time._
 import java.util.{Locale, UUID}
 
 class CoreControllerSpec extends AnyFreeSpec with Matchers {
@@ -53,7 +53,7 @@ class CoreControllerSpec extends AnyFreeSpec with Matchers {
   val validFakeHeaders = new Headers(validHeaders)
 
   "POST /oss/returns/v1/return" - {
-    "Return ok when valid payload" in {
+    "Return accepted when valid payload" in {
 
       val now = Instant.now()
       val period = Period(2021, Q3)
@@ -177,6 +177,130 @@ class CoreControllerSpec extends AnyFreeSpec with Matchers {
       val result = controller.submitVatReturn()(fakeRequestWithBody)
 
       status(result) shouldBe Status.BAD_REQUEST
+
+      val responseBody = contentAsString(result)
+      responseBody.isEmpty shouldBe false
+      val errorResponse = Json.parse(responseBody).validate[EisErrorResponse]
+      errorResponse.isSuccess shouldBe true
+    }
+
+    "Return error when using more than two decimal digits" in {
+
+      val coreVatReturn = """{
+                            |  "vatReturnReferenceNumber" : "XI/XI123456789/Q4.2021",
+                            |  "version" : "2022-03-07T14:58:07.374Z",
+                            |  "traderId" : {
+                            |    "vatNumber" : "123456789AAA",
+                            |    "issuedBy" : "XI"
+                            |  },
+                            |  "period" : {
+                            |    "year" : 2021,
+                            |    "quarter" : 3
+                            |  },
+                            |  "startDate" : "2021-07-01",
+                            |  "endDate" : "2021-09-30",
+                            |  "submissionDateTime" : "2022-03-07T14:58:07.374Z",
+                            |  "totalAmountVatDueGBP" : 5000.123456789,
+                            |  "msconSupplies" : [ {
+                            |    "msconCountryCode" : "DE",
+                            |    "balanceOfVatDueGBP" : 5000.123456789,
+                            |    "grandTotalMsidGoodsGBP" : 1000.123456789,
+                            |    "grandTotalMsestGoodsGBP" : 1000.123456789,
+                            |    "correctionsTotalGBP" : 1000.123456789,
+                            |    "msidSupplies" : [ {
+                            |      "supplyType" : "GOODS",
+                            |      "vatRate" : 10,
+                            |      "vatRateType" : "STANDARD",
+                            |      "taxableAmountGBP" : 10.123456789,
+                            |      "vatAmountGBP" : 10.123456789
+                            |    } ],
+                            |    "msestSupplies" : [ {
+                            |      "countryCode" : "DE",
+                            |      "supplies" : [ {
+                            |        "supplyType" : "GOODS",
+                            |        "vatRate" : 10,
+                            |        "vatRateType" : "STANDARD",
+                            |        "taxableAmountGBP" : 10.123456789,
+                            |        "vatAmountGBP" : 100.123456789
+                            |      } ]
+                            |    } ],
+                            |    "corrections" : [ {
+                            |      "period" : {
+                            |        "year" : 2021,
+                            |        "quarter" : 2
+                            |      },
+                            |      "totalVatAmountCorrectionGBP" : 100.123456789
+                            |    } ]
+                            |  } ]
+                            |}"""".stripMargin
+
+      val fakeRequestWithBody = fakeRequest.withJsonBody(Json.parse(coreVatReturn)).withHeaders(validFakeHeaders)
+
+      val result = controller.submitVatReturn()(fakeRequestWithBody)
+
+      status(result) shouldBe Status.BAD_REQUEST
+
+      val responseBody = contentAsString(result)
+      responseBody.isEmpty shouldBe false
+      val errorResponse = Json.parse(responseBody).validate[EisErrorResponse]
+      errorResponse.isSuccess shouldBe true
+    }
+
+    "Return error when vat rate is invalid" in {
+
+      val coreVatReturn = """{
+                            |  "vatReturnReferenceNumber" : "XI/XI123456789/Q4.2021",
+                            |  "version" : "2022-03-07T14:58:07.374Z",
+                            |  "traderId" : {
+                            |    "vatNumber" : "123456789AAA",
+                            |    "issuedBy" : "XI"
+                            |  },
+                            |  "period" : {
+                            |    "year" : 2021,
+                            |    "quarter" : 3
+                            |  },
+                            |  "startDate" : "2021-07-01",
+                            |  "endDate" : "2021-09-30",
+                            |  "submissionDateTime" : "2022-03-07T14:58:07.374Z",
+                            |  "totalAmountVatDueGBP" : 5000.12,
+                            |  "msconSupplies" : [ {
+                            |    "msconCountryCode" : "DE",
+                            |    "balanceOfVatDueGBP" : 5000.12,
+                            |    "grandTotalMsidGoodsGBP" : 1000.12,
+                            |    "grandTotalMsestGoodsGBP" : 1000.12,
+                            |    "correctionsTotalGBP" : 1000.12,
+                            |    "msidSupplies" : [ {
+                            |      "supplyType" : "GOODS",
+                            |      "vatRate" : 101,
+                            |      "vatRateType" : "STANDARD",
+                            |      "taxableAmountGBP" : 10.12,
+                            |      "vatAmountGBP" : 10.12
+                            |    } ],
+                            |    "msestSupplies" : [ {
+                            |      "countryCode" : "DE",
+                            |      "supplies" : [ {
+                            |        "supplyType" : "GOODS",
+                            |        "vatRate" : 10.001,
+                            |        "vatRateType" : "STANDARD",
+                            |        "taxableAmountGBP" : 10.12,
+                            |        "vatAmountGBP" : 100.12
+                            |      } ]
+                            |    } ],
+                            |    "corrections" : [ {
+                            |      "period" : {
+                            |        "year" : 2021,
+                            |        "quarter" : 2
+                            |      },
+                            |      "totalVatAmountCorrectionGBP" : 100.12
+                            |    } ]
+                            |  } ]
+                            |}"""".stripMargin
+
+      val fakeRequestWithBody = fakeRequest.withJsonBody(Json.parse(coreVatReturn)).withHeaders(validFakeHeaders)
+
+      val result = controller.submitVatReturn()(fakeRequestWithBody)
+
+      status(result) shouldBe Status.BAD_REQUEST
     }
 
     "Return bad request when headers are missing" in {
@@ -238,15 +362,84 @@ class CoreControllerSpec extends AnyFreeSpec with Matchers {
   }
 
   "POST /oss/referencedata/v1/exchangerate must" - {
-    val timestamp = LocalDateTime.of(2022, 1, 1, 1, 1, 1, 123000000)
+    val timestamp = LocalDateTime.of(2022, 1, 1, 1, 1)
     val base = "EUR"
     val target = "GBP"
-    val rate = CoreRate(timestamp.toLocalDate, BigDecimal(10))
-    val exchangeRateRequest = CoreExchangeRateRequest(base, target, timestamp, Seq(rate))
-    "return ok for a valid json" in {
+    val rate = CoreRate(
+      timestamp.toLocalDate,
+      BigDecimal(10))
+
+    val exchangeRateRequest = CoreExchangeRateRequest(
+      base,
+      target,
+      timestamp,
+      Seq(rate))
+
+    "return ok for valid json" in {
+
       val fakeRequestWithBody = fakeRequest.withJsonBody(Json.toJson(exchangeRateRequest)).withHeaders(validFakeHeaders)
+
       val result = controller.submitRates()(fakeRequestWithBody)
+
       status(result) shouldBe Status.OK
+    }
+
+    "return bad request for a timestamp without milliseconds" in {
+
+      val badJson = """{
+                      |  "base" : "EUR",
+                      |  "target" : "GBP",
+                      |  "timestamp" : "2022-01-01T01:01:00Z",
+                      |  "rates" : [ {
+                      |    "publishedDate" : "2022-01-10",
+                      |    "rate" : 10
+                      |  } ]
+                      |}""".stripMargin
+
+      val fakeRequestWithBody = fakeRequest.withJsonBody(Json.parse(badJson)).withHeaders(validFakeHeaders)
+
+      val result = controller.submitRates()(fakeRequestWithBody)
+
+      status(result) shouldBe Status.BAD_REQUEST
+    }
+
+    "return bad request for a published date that includes hours, minutes and seconds" in {
+
+      val badJson = """{
+                      |  "base" : "EUR",
+                      |  "target" : "GBP",
+                      |  "timestamp" : "2022-01-01T01:01:00.000Z",
+                      |  "rates" : [ {
+                      |    "publishedDate" : "2022-01-01T01:01:00.000Z",
+                      |    "rate" : 10
+                      |  } ]
+                      |}""".stripMargin
+
+      val fakeRequestWithBody = fakeRequest.withJsonBody(Json.parse(badJson)).withHeaders(validFakeHeaders)
+
+      val result = controller.submitRates()(fakeRequestWithBody)
+
+      status(result) shouldBe Status.BAD_REQUEST
+    }
+
+    "return bad request for an invalid published date" in {
+
+      val badJson = """{
+                      |  "base" : "EUR",
+                      |  "target" : "GBP",
+                      |  "timestamp" : "2022-01-01T01:01:00.000Z",
+                      |  "rates" : [ {
+                      |    "publishedDate" : "hello",
+                      |    "rate" : 10
+                      |  } ]
+                      |}""".stripMargin
+
+      val fakeRequestWithBody = fakeRequest.withJsonBody(Json.parse(badJson)).withHeaders(validFakeHeaders)
+
+      val result = controller.submitRates()(fakeRequestWithBody)
+
+      status(result) shouldBe Status.BAD_REQUEST
+
     }
 
 
@@ -256,13 +449,11 @@ class CoreControllerSpec extends AnyFreeSpec with Matchers {
       val result = controller.submitRates()(fakeRequestWithBody)
 
       status(result) shouldBe Status.BAD_REQUEST
+
     }
 
     "return Conflict for the 20th of the month" in {
-      val fakeRequestWithBody = fakeRequest.withJsonBody(Json.toJson(
-        exchangeRateRequest.copy(timestamp =
-          LocalDateTime.of(2022, 1, 20, 1, 1))))
-        .withHeaders(validFakeHeaders)
+      val fakeRequestWithBody = fakeRequest.withJsonBody(Json.toJson(exchangeRateRequest.copy(timestamp = LocalDateTime.of(2022, 1, 20, 1, 1)))).withHeaders(validFakeHeaders)
 
       val result = controller.submitRates()(fakeRequestWithBody)
 

--- a/test/uk/gov/hmrc/onestopshopreturnsstub/models/core/CoreExchangeRateRequestSpec.scala
+++ b/test/uk/gov/hmrc/onestopshopreturnsstub/models/core/CoreExchangeRateRequestSpec.scala
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.onestopshopreturnsstub.models.core
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.{JsPath, JsResult, Json, JsonValidationError}
+
+import java.time.{Instant, LocalDate, LocalDateTime, ZoneId}
+
+class CoreExchangeRateRequestSpec extends AnyFreeSpec with Matchers  {
+
+  "Core Exchange Rate Request" - {
+
+    "should validate" in {
+
+      val json = """{
+                   |  "base" : "EUR",
+                   |  "target" : "GBP",
+                   |  "timestamp" : "2022-03-10T01:10:01.032Z",
+                   |  "rates" : [
+                   |  {
+                   |    "publishedDate" : "2022-03-10",
+                   |    "rate" : 0.4
+                   |  },
+                   |  {
+                   |    "publishedDate" : "2022-03-09",
+                   |    "rate" : 0.5
+                   |  },
+                   |  {
+                   |    "publishedDate" : "2022-03-08",
+                   |    "rate" : 0.6
+                   |  } ]
+                   |}""".stripMargin
+
+      val validated: JsResult[CoreExchangeRateRequest] = Json.parse(json).validate[CoreExchangeRateRequest]
+
+      val expected = CoreExchangeRateRequest(
+        "EUR",
+        "GBP",
+        LocalDateTime.ofInstant(Instant.parse("2022-03-10T01:10:01.032Z"), ZoneId.systemDefault()),
+        Seq(
+          CoreRate(LocalDate.of(2022, 3, 10), BigDecimal(0.4)),
+          CoreRate(LocalDate.of(2022, 3, 9), BigDecimal(0.5)),
+          CoreRate(LocalDate.of(2022, 3, 8), BigDecimal(0.6))
+      ))
+
+      validated.isSuccess shouldBe true
+      validated.get shouldBe expected
+    }
+
+    "should fail for timestamp without milliseconds" in {
+
+      val json = """{
+                   |  "base" : "EUR",
+                   |  "target" : "GBP",
+                   |  "timestamp" : "2022-03-10T01:10:01Z",
+                   |  "rates" : [
+                   |  {
+                   |    "publishedDate" : "2022-03-10",
+                   |    "rate" : 0.4
+                   |  },
+                   |  {
+                   |    "publishedDate" : "2022-03-09",
+                   |    "rate" : 0.5
+                   |  },
+                   |  {
+                   |    "publishedDate" : "2022-03-08",
+                   |    "rate" : 0.6
+                   |  } ]
+                   |}""".stripMargin
+
+      val validated: JsResult[CoreExchangeRateRequest] = Json.parse(json).validate[CoreExchangeRateRequest]
+
+      val either = validated.asEither
+
+      either.isLeft shouldBe true
+      val error = either.left.get.head
+
+      error._1 shouldBe JsPath \ ("timestamp")
+      error._2 shouldBe Seq(JsonValidationError("Not a valid date-time of format yyyy-MM-ddThh:mm:ss.SSSZ"))
+    }
+
+    "should fail for currencies that are not 3 characters" in {
+
+      val json = """{
+                   |  "base" : "EU",
+                   |  "target" : "GBP",
+                   |  "timestamp" : "2022-03-10T01:10:01.123Z",
+                   |  "rates" : [
+                   |  {
+                   |    "publishedDate" : "2022-03-10",
+                   |    "rate" : 0.4
+                   |  },
+                   |  {
+                   |    "publishedDate" : "2022-03-09",
+                   |    "rate" : 0.5
+                   |  },
+                   |  {
+                   |    "publishedDate" : "2022-03-08",
+                   |    "rate" : 0.6
+                   |  } ]
+                   |}""".stripMargin
+
+      val validated: JsResult[CoreExchangeRateRequest] = Json.parse(json).validate[CoreExchangeRateRequest]
+
+      val either = validated.asEither
+
+      either.isLeft shouldBe true
+      val error = either.left.get.head
+
+      error._1 shouldBe JsPath \ ("base")
+      error._2 shouldBe Seq(JsonValidationError("error.minLength", 3))
+    }
+
+    "handle multiple errors" in {
+
+      val json = """{
+                   |  "base" : "EUR",
+                   |  "target" : "GB",
+                   |  "timestamp" : "2022-03-10",
+                   |  "rates" : [
+                   |  {
+                   |    "publishedDate" : "2022-03-10T01:10:01.123Z",
+                   |    "rate" : 0.4
+                   |  },
+                   |  {
+                   |    "publishedDate" : "2022-03-09",
+                   |    "rate" : 0.5
+                   |  },
+                   |  {
+                   |    "publishedDate" : "2022-03-08",
+                   |    "rate" : 0.6
+                   |  } ]
+                   |}""".stripMargin
+
+      val validated: JsResult[CoreExchangeRateRequest] = Json.parse(json).validate[CoreExchangeRateRequest]
+
+      val either = validated.asEither
+
+      either.isLeft shouldBe true
+      val errors = either.left.get
+
+      errors.head._1 shouldBe JsPath \ "target"
+      errors.head._2 shouldBe Seq(JsonValidationError("error.minLength", 3))
+
+      errors(1)._1 shouldBe JsPath \ "timestamp"
+      errors(1)._2 shouldBe Seq(JsonValidationError("Not a valid date-time of format yyyy-MM-ddThh:mm:ss.SSSZ"))
+
+      errors(2)._1 shouldBe JsPath \ "rates" \ 0 \ "publishedDate"
+      errors(2)._2 shouldBe Seq(JsonValidationError("Not a valid date with format yyyy-MM-dd"))
+    }
+  }
+}

--- a/test/uk/gov/hmrc/onestopshopreturnsstub/models/core/CoreRateSpec.scala
+++ b/test/uk/gov/hmrc/onestopshopreturnsstub/models/core/CoreRateSpec.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.onestopshopreturnsstub.models.core
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.{JsPath, JsResult, Json, JsonValidationError}
+
+import java.time.LocalDate
+
+class CoreRateSpec extends AnyFreeSpec with Matchers  {
+
+  "Core Rate" - {
+    "should validate" in {
+
+      val json = """{
+                   |  "publishedDate" : "2022-03-10",
+                   |  "rate" : 0.5
+                   |}""".stripMargin
+
+      val validated: JsResult[CoreRate] = Json.parse(json).validate[CoreRate]
+
+      val expected: CoreRate = CoreRate(LocalDate.of(2022, 3, 10), BigDecimal(0.5))
+
+      validated.isSuccess shouldBe true
+      validated.get shouldBe expected
+    }
+
+    "should fail for date in unexpected format" in {
+
+      val json = """{
+                   |  "publishedDate" : "2022-03-10T10:01:10.123Z",
+                   |  "rate" : 0.5
+                   |}""".stripMargin
+
+      val validated: JsResult[CoreRate] = Json.parse(json).validate[CoreRate]
+
+      val either = validated.asEither
+
+      either.isLeft shouldBe true
+      val error = either.left.get.head
+
+      error._1 shouldBe JsPath \ ("publishedDate")
+      error._2 shouldBe Seq(JsonValidationError("Not a valid date with format yyyy-MM-dd"))
+    }
+
+    "should fail for invalid date" in {
+
+      val json = """{
+                   |  "publishedDate" : "2022-03-34",
+                   |  "rate" : 0.5
+                   |}""".stripMargin
+
+      val validated: JsResult[CoreRate] = Json.parse(json).validate[CoreRate]
+
+      val either = validated.asEither
+
+      either.isLeft shouldBe true
+      val error = either.left.get.head
+
+      error._1 shouldBe JsPath \ ("publishedDate")
+      error._2 shouldBe Seq(JsonValidationError("Not a valid date with format yyyy-MM-dd"))
+    }
+  }
+}


### PR DESCRIPTION
Uses JSON Reads to validate Forex data, due to errors reading JSON schema. 
Also added JSON Reads validation to the existing validation for returns to catch missing validation due to schema errors.